### PR TITLE
Add full git history fetch to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
     container: makeappdev/uselatex:latest
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
+          
       - name: Configure Git safe directory with GITHUB_WORKSPACE
         run: git config --global --add safe.directory $GITHUB_WORKSPACE
         


### PR DESCRIPTION
@hofbi I forgot we need this so that `git rev-list HEAD --count` returns the correct commit number for `\GitRevision`. Thats why I had it initally in my previous PR.